### PR TITLE
Prefilter fix

### DIFF
--- a/5.5/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeScorer.java
+++ b/5.5/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeScorer.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.util.Bits;
 
 import java.io.IOException;
 import java.util.Map;
@@ -15,6 +16,7 @@ public class TraveltimeScorer extends Scorer {
    protected final TraveltimeWeight weight;
    private final Map<Coordinates, Integer> pointToTime;
    private final TraveltimeFilteredDocs docs;
+   private final Bits live;
    private final float boost;
 
    @AllArgsConstructor
@@ -33,7 +35,7 @@ public class TraveltimeScorer extends Scorer {
          int id = backing.nextDoc();
          while (id != DocIdSetIterator.NO_MORE_DOCS) {
             backingCoords.setDocument(id);
-            if (backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
+            if (live.get(id) && backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
                return id;
             }
             id = backing.nextDoc();
@@ -46,7 +48,7 @@ public class TraveltimeScorer extends Scorer {
          int id = backing.advance(target);
          if(id == DocIdSetIterator.NO_MORE_DOCS) return id;
          backingCoords.setDocument(id);
-         if (backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
+         if (live.get(id) && backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
             return id;
          } else {
             return nextDoc();
@@ -59,11 +61,12 @@ public class TraveltimeScorer extends Scorer {
       }
    }
 
-   public TraveltimeScorer(TraveltimeWeight w, Map<Coordinates, Integer> coordToTime, DocIdSetIterator docs, SortedNumericDocValues coords, float boost) {
+   public TraveltimeScorer(TraveltimeWeight w, Map<Coordinates, Integer> coordToTime, DocIdSetIterator docs, SortedNumericDocValues coords, Bits live, float boost) {
       super(w);
       this.weight = w;
       this.pointToTime = coordToTime;
       this.docs = new TraveltimeFilteredDocs(docs, coords);
+      this.live = live;
       this.boost = boost;
    }
 

--- a/5.5/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeScorer.java
+++ b/5.5/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeScorer.java
@@ -35,7 +35,7 @@ public class TraveltimeScorer extends Scorer {
          int id = backing.nextDoc();
          while (id != DocIdSetIterator.NO_MORE_DOCS) {
             backingCoords.setDocument(id);
-            if (live.get(id) && backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
+            if ((live == null || live.get(id)) && backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
                return id;
             }
             id = backing.nextDoc();
@@ -48,7 +48,7 @@ public class TraveltimeScorer extends Scorer {
          int id = backing.advance(target);
          if(id == DocIdSetIterator.NO_MORE_DOCS) return id;
          backingCoords.setDocument(id);
-         if (live.get(id) && backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
+         if ((live == null || live.get(id)) && backingCoords.count() > 0 && pointToTime.containsKey(Util.decode(backingCoords.valueAt(0)))) {
             return id;
          } else {
             return nextDoc();

--- a/7.10/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.10/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.10/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.10/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.11/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.11/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.11/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.11/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.12/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.12/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.12/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.12/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.13/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.13/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.13/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.13/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.14/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.14/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.14/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.14/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.15/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.15/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.15/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.15/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.16/build.gradle
+++ b/7.16/build.gradle
@@ -1,1 +1,1 @@
-buildPlugin(this, '7.16', ['0', '1', '2', '3-SNAPSHOT'])
+buildPlugin(this, '7.16', ['0', '1', '2', '3', '4-SNAPSHOT'])

--- a/7.16/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.16/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.16/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.16/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/7.17/build.gradle
+++ b/7.17/build.gradle
@@ -1,1 +1,1 @@
-buildPlugin(this, '7.17', ['0', '1', '2-SNAPSHOT'])
+buildPlugin(this, '7.17', ['0', '1', '2', '3', '4-SNAPSHOT'])

--- a/7.17/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.17/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
@@ -57,8 +59,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -73,11 +108,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -105,7 +148,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/7.17/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/7.17/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -73,7 +73,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/8.0/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/8.0/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -67,7 +67,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/8.0/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/8.0/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
 
@@ -51,8 +53,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -67,11 +102,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -99,7 +142,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/8.1/build.gradle
+++ b/8.1/build.gradle
@@ -1,4 +1,4 @@
-buildPlugin(this, '8.1', ['0', '1', '2', '3-SNAPSHOT'])
+buildPlugin(this, '8.1', ['0', '1', '2', '3', '4-SNAPSHOT'])
 
 compileJava {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/8.1/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/8.1/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -67,7 +67,8 @@ public class TraveltimeWeight extends Weight {
       }
 
       public boolean advanceExact(int target) throws IOException {
-         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+         this.filtered.advance(target);
+         return this.values.docValueCount() > 0;
       }
 
       public int docID() {

--- a/8.1/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
+++ b/8.1/src/main/java/com/traveltime/plugin/elasticsearch/query/TraveltimeWeight.java
@@ -10,10 +10,12 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.*;
 import org.elasticsearch.SpecialPermission;
 
@@ -51,8 +53,41 @@ public class TraveltimeWeight extends Weight {
       return Explanation.noMatch("Cannot provide explanation for traveltime matches");
    }
 
-   @Override
-   public Scorer scorer(LeafReaderContext context) throws IOException {
+   @RequiredArgsConstructor
+   public static class FilteredIterator extends SortedNumericDocValues {
+      private final SortedNumericDocValues values;
+      private final DocIdSetIterator filtered;
+
+      public long nextValue() throws IOException {
+         return this.values.nextValue();
+      }
+
+      public int docValueCount() {
+         return this.values.docValueCount();
+      }
+
+      public boolean advanceExact(int target) throws IOException {
+         return this.filtered.advance(target) != NO_MORE_DOCS && this.values.docValueCount() > 0;
+      }
+
+      public int docID() {
+         return this.filtered.docID();
+      }
+
+      public int nextDoc() throws IOException {
+         return this.filtered.nextDoc();
+      }
+
+      public int advance(int target) throws IOException {
+         return this.filtered.advance(target);
+      }
+
+      public long cost() {
+         return this.filtered.cost();
+      }
+   }
+
+   private FilteredIterator filteredValues(LeafReaderContext context) throws IOException {
       val reader = context.reader();
       val backing = reader.getSortedNumericDocValues(ttQuery.getParams().getField());
 
@@ -67,11 +102,19 @@ public class TraveltimeWeight extends Weight {
          finalIterator = backing;
       }
 
+      return new FilteredIterator(backing, finalIterator);
+   }
+
+   @Override
+   public Scorer scorer(LeafReaderContext context) throws IOException {
+      val backing = filteredValues(context);
+      if (backing == null) return null;
+
       val valueArray = new LongArrayList();
       val decodedArray = new ArrayList<Coordinates>();
       val valueSet = new LongOpenHashSet();
 
-      while (finalIterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      while (backing.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
          long encodedCoords = backing.nextValue();
          if(valueSet.add(encodedCoords)) {
             valueArray.add(encodedCoords);
@@ -99,7 +142,7 @@ public class TraveltimeWeight extends Weight {
          TraveltimeCache.INSTANCE.add(ttQuery.getParams(), pointToTime);
       }
 
-      return new TraveltimeScorer(this, pointToTime, reader.getSortedNumericDocValues(ttQuery.getParams().getField()), boost);
+      return new TraveltimeScorer(this, pointToTime, filteredValues(context), boost);
    }
 
    @Override

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ configure(subprojects - common) {
         implementation(common) {
             exclude group: 'org.apache.logging.log4j'
         }
-        implementation('com.traveltime:traveltime-sdk-java:1.1.11') {
+        implementation('com.traveltime:traveltime-sdk-java:1.1.17') {
             exclude group: 'com.fasterxml.jackson.core'
             exclude group: 'org.locationtech.jts'
         }

--- a/common/src/universal/run-tests.sh
+++ b/common/src/universal/run-tests.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-trap "docker stop $IMAGE_NAME; exit 1" EXIT
+trap "docker logs $IMAGE_NAME; docker stop $IMAGE_NAME; exit 1" EXIT
 
 docker run -d \
   -e "discovery.type=single-node" \


### PR DESCRIPTION
The problem was that we used the prefilter when fetching coordinates from the index, but did not when we scored documents.
The bug manifested when two documents had identical coordinates but only one satisfied the filter - both would be returned.